### PR TITLE
patch AUTH_URL, token validation, poll precedence, FAILED state

### DIFF
--- a/.github/workflows/Container-Build-Cloud-Service-demo.yml
+++ b/.github/workflows/Container-Build-Cloud-Service-demo.yml
@@ -51,7 +51,7 @@ jobs:
           # fetch_token is used for periodic token refresh inside the polling loop
           # (composite actions cannot be called from within a bash script)
           fetch_token() {
-            local resp
+            local resp token
             resp=$(curl --location --request POST "$AUTH_URL" \
               --header 'Content-Type: application/x-www-form-urlencoded' \
               --header 'accept: application/json' \
@@ -59,7 +59,9 @@ jobs:
               --data-urlencode 'client_secret=${{ secrets.DEMO_CLIENT_SECRET }}' \
               --data-urlencode 'grant_type=client_credentials' \
               --data-urlencode 'scope=${{ secrets.CLOUD_HUB_PROJECT_ID }}:${{ secrets.CLOUD_HUB_APPLICATION_ID }}')
-            echo "$resp" | jq -r '.access_token'
+            token=$(echo "$resp" | jq -er '.access_token | select(length > 0)')
+            echo "::add-mask::$token"
+            printf '%s\n' "$token"
           }
 
           payload=$(jq -n \
@@ -81,9 +83,9 @@ jobs:
                 inputObjectKey: $inputObjectKey,
                 configurationObjectKey: $configurationObjectKey
             }')
-          
+
           echo "$payload"
-          
+
           response=$(curl --location --request POST "${{ secrets.DEMO_API_URL }}" \
             --header "accept: application/json" \
             --header "Authorization: Bearer $TOKEN" \
@@ -113,7 +115,7 @@ jobs:
           status="ACCEPTED"
           max_attempts=360 # maximum 3 hours
           attempt=0
-          while [[ "$status" == "ACCEPTED" || "$status" == "MALWARE-SCANNING" || "$status" == "RUNNING" || "$status" == "DOWNLOADING" || "$status" == "QUEUED" && $attempt -lt $max_attempts ]]; do
+          while [[ $attempt -lt $max_attempts && ( "$status" == "ACCEPTED" || "$status" == "MALWARE-SCANNING" || "$status" == "RUNNING" || "$status" == "DOWNLOADING" || "$status" == "QUEUED" ) ]]; do
             echo "Polling attempt $((attempt+1))..."
             sleep 30  # Wait for 30 seconds before the next poll
 
@@ -146,15 +148,25 @@ jobs:
             attempt=$((attempt+1))
           done
 
-          if [[ "$status" != "FINISHED" ]]; then
-            echo "Job did not complete in time."
-            exit 1
-          fi
+          case "$status" in
+            FINISHED)
+              ;;
+            FAILED)
+              echo "Container-build service reported FAILED."
+              echo "$http_body"
+              exit 1
+              ;;
+            *)
+              echo "Container build timed out in state: $status"
+              exit 1
+              ;;
+          esac
 
           echo "TASK_ID=$task_id" >> $GITHUB_ENV
           echo "SELF_HREF=$container_resource" >> $GITHUB_ENV
           echo "Job completed successfully."
         env:
+          AUTH_URL: ${{ secrets.AUTH_URL }}
           STEPS_AUTH_OUTPUTS_TOKEN: ${{ steps.auth.outputs.token }}
           GITHUB_EVENT_INPUTS_STORAGE_TYPE: ${{ github.event.inputs.storage_type }}
           GITHUB_EVENT_INPUTS_STORAGE_URL: ${{ github.event.inputs.storage_url }}


### PR DESCRIPTION
- Add AUTH_URL to Trigger EHANDBOOK API env block so the inline fetch_token() function can resolve it during token refresh (fixes the curl malformed-URL / HTTP 403 seen at ~549s in run #10)
- Harden fetch_token() with jq -er + select(length > 0) to reject empty tokens; add ::add-mask:: to prevent accidental log exposure
- Fix while-loop operator precedence: move attempt < max_attempts guard first and group status checks in ( ... ) so the cap applies to all in-progress states, not just QUEUED
- Replace post-loop if/fi with a case statement that exits 1 with a distinct message for FAILED vs. timeout,